### PR TITLE
Send check status to prometheus pushgateway

### DIFF
--- a/cleanup/check_account.py
+++ b/cleanup/check_account.py
@@ -196,6 +196,9 @@ def verify_accounts(saa_api_key, saa_url, push_gw_url):
             push_to_prometheus(push_gw_url, 'verify_accounts', 'ibm_current_usage', 'Current usage by account',
                                current_cost, labels)
 
+            push_to_prometheus(push_gw_url, 'verify_accounts', 'ibm_previous_usage', 'Previous usage by account',
+                               previous_cost, labels)
+
             if current_cost > previous_cost:
                 logging.warning(
                     f"The current charges of {current_cost} are greater than the previous charges of {previous_cost} in account {account_name}.")

--- a/cleanup/requirements.txt
+++ b/cleanup/requirements.txt
@@ -20,3 +20,4 @@ requests==2.25.1
 s3transfer==0.3.3
 six==1.15.0
 urllib3==1.26.2
+prometheus-client==0.9.0


### PR DESCRIPTION

* Requires a new env variable PUSH_GATEWAY_URL with url for the pushgatway
* Add `prometheus-client` to requirements
* Two metrics to pushgateway
  `ibm_clean_accounts`: This is used by `clean_accounts` function with value 0 for success and 1 failed, also added three labels to the metrics:
    `account`: Account Name
    `cloud_provider`: Cloud Provider
    `status`: it will be 'success' or 'failed'
   `ibm_current_usage`: Current usage in US for by account during the verification function and also added two labels
    `account`: Account Name
    `cloud_provider`: Cloud Provider

Labels can be a a dict to add as label to the metric.