### PR TITLE
Update verification time to waiting 24 hours

### DIFF
--- a/cleanup/app.py
+++ b/cleanup/app.py
@@ -120,7 +120,7 @@ def verify_accounts(saa_api_key, saa_url, push_gw_url):
             cloud_provider = account['cloud_provider']['S']
             logging.info(f"Starting verification of account {account_name}")
             cleanup_time = datetime.fromisoformat(account['cleanup_time']['S'])
-            verification_time = cleanup_time + timedelta(hours=3)
+            verification_time = cleanup_time + timedelta(hours=24)
             labels = {'account': account_name, 'cloud_provider': cloud_provider}
             if datetime.now(timezone.utc) >= verification_time:
                 logging.info(f"Evaluating account {account['account_name']['S']}.")


### PR DESCRIPTION
This PR update the verification process to wait 24 hours before start the process and release the sandbox account to be used again.
